### PR TITLE
feat: update to use `laravel/serializable-closure` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ composer require amphp/parallel-functions
 
 ## Requirements
 
-- PHP 7.0+
+- PHP 7.4+
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.4",
         "amphp/parallel": "^1.1",
         "amphp/amp": "^2.0.3",
-        "opis/closure": "^3.0.7"
+        "laravel/serializable-closure": "^1.0"
     },
     "require-dev": {
         "amphp/php-cs-fixer-config": "v2.x-dev",

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,7 +6,7 @@ use Amp\MultiReasonException;
 use Amp\Parallel\Sync\SerializationException;
 use Amp\Parallel\Worker\Pool;
 use Amp\Promise;
-use Opis\Closure\SerializableClosure;
+use Laravel\SerializableClosure\SerializableClosure;
 use function Amp\call;
 use function Amp\Parallel\Worker\enqueue;
 use function Amp\Promise\any;


### PR DESCRIPTION
This allows supporting PHP 8.1, and is required for us to continue using this package with Box, as 4.x of `opis/closure` requires FFI, which afaik isn't wanted for Box. Happy to make any changes if required. 👍🏻

It looks like Travis doesn't yet support PHP `8.1` (unless it's hardcoded to `8.1.0`) 🤷🏻

Also, looks like the quotes were changed in error messages as part of PHP 8.0 (see https://github.com/php/php-src/pull/5590), so I've updated the `testUnserializableClassStaticMethod()` test to cover this.

---

> NOTE: This can be rebased after https://github.com/amphp/parallel-functions/pull/30 and https://github.com/amphp/parallel-functions/pull/31 have been merged. 👍🏻