### PR TITLE
Update to php-cs-fixer v3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,13 +3,12 @@ examples export-ignore
 test export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.php_cs.dist export-ignore
+.php-cs-fixer.dist.php export-ignore
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore
 README.md export-ignore
 CONTRIBUTING.md export-ignore
 CHANGELOG.md export-ignore
-.php-cs-fixer.dist.php export-ignore
 .gitmodules export-ignore
 .editorconfig export-ignore
 docs/asset export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,7 @@ phpunit.xml.dist export-ignore
 README.md export-ignore
 CONTRIBUTING.md export-ignore
 CHANGELOG.md export-ignore
-.php_cs.dist export-ignore
+.php-cs-fixer.dist.php export-ignore
 .gitmodules export-ignore
 .editorconfig export-ignore
 docs/asset export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor/
 /composer.lock
-/.php_cs.cache
+/.php-cs-fixer.cache
 /docs/Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor/
 /composer.lock
-/.php-cs-fixer.cache
+/.php_cs.cache
 /docs/Gemfile.lock

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         "@PSR1" => true,
@@ -14,7 +14,7 @@ return PhpCsFixer\Config::create()
         "combine_consecutive_unsets" => true,
         "function_to_constant" => true,
         "native_function_invocation" => true,
-        "no_multiline_whitespace_before_semicolons" => true,
+        "multiline_whitespace_before_semicolons" => true,
         "no_unused_imports" => true,
         "no_useless_else" => true,
         "no_useless_return" => true,
@@ -28,7 +28,7 @@ return PhpCsFixer\Config::create()
         "php_unit_fqcn_annotation" => true,
         "phpdoc_summary" => true,
         "phpdoc_types" => true,
-        "psr4" => true,
+        "psr_autoloading" => true,
         "return_type_declaration" => ["space_before" => "none"],
         "short_scalar_cast" => true,
         "single_blank_line_before_namespace" => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,41 +1,12 @@
 <?php
 
-return (new PhpCsFixer\Config())
-    ->setRiskyAllowed(true)
-    ->setRules([
-        "@PSR1" => true,
-        "@PSR2" => true,
-        "braces" => [
-            "allow_single_line_closure" => true,
-            "position_after_functions_and_oop_constructs" => "same",
-        ],
-        "array_syntax" => ["syntax" => "short"],
-        "cast_spaces" => true,
-        "combine_consecutive_unsets" => true,
-        "function_to_constant" => true,
-        "native_function_invocation" => true,
-        "multiline_whitespace_before_semicolons" => true,
-        "no_unused_imports" => true,
-        "no_useless_else" => true,
-        "no_useless_return" => true,
-        "no_whitespace_before_comma_in_array" => true,
-        "no_whitespace_in_blank_line" => true,
-        "non_printable_character" => true,
-        "normalize_index_brace" => true,
-        "ordered_imports" => true,
-        "php_unit_construct" => true,
-        "php_unit_dedicate_assert" => true,
-        "php_unit_fqcn_annotation" => true,
-        "phpdoc_summary" => true,
-        "phpdoc_types" => true,
-        "psr_autoloading" => true,
-        "return_type_declaration" => ["space_before" => "none"],
-        "short_scalar_cast" => true,
-        "single_blank_line_before_namespace" => true,
-    ])
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->in(__DIR__ . "/examples")
-            ->in(__DIR__ . "/src")
-            ->in(__DIR__ . "/test")
-    );
+$config = new Amp\CodeStyle\Config;
+$config->getFinder()
+    ->in(__DIR__ . "/examples")
+    ->in(__DIR__ . "/src")
+    ->in(__DIR__ . "/test");
+
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+$config->setCacheFile($cacheDir . '/.php_cs.cache');
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 language: php
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
+  - 7.4
+  - 8.0
   - nightly
 
 matrix:
@@ -36,3 +35,4 @@ after_script:
 cache:
   directories:
     - $HOME/.composer/cache/files
+    - $HOME/.php-cs-fixer

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "amphp/phpunit-util": "^2.0",
-        "friendsofphp/php-cs-fixer": "^2.9",
+        "friendsofphp/php-cs-fixer": "^3.5",
         "phpunit/phpunit": "^9.5.11"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -23,19 +23,19 @@
         }
     },
     "require": {
-        "php": ">=7",
+        "php": ">=7.4",
         "amphp/parallel": "^1.1",
         "amphp/amp": "^2.0.3",
         "opis/closure": "^3.0.7"
     },
     "require-dev": {
+        "amphp/php-cs-fixer-config": "v2.x-dev",
         "amphp/phpunit-util": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.5",
         "phpunit/phpunit": "^9.5.11"
     },
     "config": {
         "platform": {
-            "php": "7.0.0"
+            "php": "7.4"
         }
     },
     "scripts": {

--- a/examples/1-simple-function.php
+++ b/examples/1-simple-function.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use function Amp\ParallelFunctions\parallelMap;
 use function Amp\Promise\wait;
 
-$start = \microtime(true);
+$start = microtime(true);
 
 // sleep() is executed in child processes, the results are sent back to the parent.
 //
@@ -13,4 +13,4 @@ $start = \microtime(true);
 // in a traditional synchronous environment.
 wait(parallelMap([1, 2, 3], 'sleep'));
 
-print 'Took ' . (\microtime(true) - $start) . ' seconds.' . \PHP_EOL;
+print 'Took ' . (microtime(true) - $start) . ' seconds.' . \PHP_EOL;

--- a/examples/3-return-value.php
+++ b/examples/3-return-value.php
@@ -6,4 +6,4 @@ use function Amp\ParallelFunctions\parallelMap;
 use function Amp\Promise\wait;
 
 // We have seen that the order can vary in the previous example, values returned have a deterministic order.
-\var_dump(wait(parallelMap([1, 2, 3], 'abs')));
+var_dump(wait(parallelMap([1, 2, 3], 'abs')));

--- a/examples/4-closure.php
+++ b/examples/4-closure.php
@@ -7,8 +7,8 @@ use function Amp\Promise\wait;
 
 // Parallel function execution is nice, but it's even better being able to use closures instead of having to write a
 // function that has to be autoloadable.
-\var_dump(wait(parallelMap([1, 2, 3], function ($time) {
-    \sleep($time); // a blocking function call, might also do blocking I/O here
+var_dump(wait(parallelMap([1, 2, 3], function ($time) {
+    sleep($time); // a blocking function call, might also do blocking I/O here
 
     return $time * $time;
 })));

--- a/examples/5-many-pools.php
+++ b/examples/5-many-pools.php
@@ -13,7 +13,7 @@ use function Amp\Promise\wait;
 for ($i = 0; $i < 30; $i++) {
     $pool = new DefaultPool();
 
-    $promises = parallelMap(\range(1, 50), function () {
+    $promises = parallelMap(range(1, 50), function () {
         return 2;
     }, $pool);
 

--- a/src/Internal/SerializedCallableTask.php
+++ b/src/Internal/SerializedCallableTask.php
@@ -6,7 +6,8 @@ use Amp\Parallel\Worker\Environment;
 use Amp\Parallel\Worker\Task;
 
 /** @internal */
-class SerializedCallableTask implements Task {
+class SerializedCallableTask implements Task
+{
     /** @var string */
     private $function;
 
@@ -17,13 +18,15 @@ class SerializedCallableTask implements Task {
      * @param string $function Serialized function.
      * @param array  $args Arguments to pass to the function. Must be serializable.
      */
-    public function __construct(string $function, array $args) {
+    public function __construct(string $function, array $args)
+    {
         $this->function = $function;
         $this->args = $args;
     }
 
-    public function run(Environment $environment) {
-        $callable = unserialize($this->function, ['allowed_classes' => true]);
+    public function run(Environment $environment)
+    {
+        $callable = \unserialize($this->function, ['allowed_classes' => true]);
 
         if ($callable instanceof \__PHP_Incomplete_Class) {
             throw new \Error('When using a class instance as a callable, the class must be autoloadable');

--- a/src/Internal/SerializedCallableTask.php
+++ b/src/Internal/SerializedCallableTask.php
@@ -23,7 +23,7 @@ class SerializedCallableTask implements Task {
     }
 
     public function run(Environment $environment) {
-        $callable = \unserialize($this->function, ['allowed_classes' => true]);
+        $callable = unserialize($this->function, ['allowed_classes' => true]);
 
         if ($callable instanceof \__PHP_Incomplete_Class) {
             throw new \Error('When using a class instance as a callable, the class must be autoloadable');

--- a/src/functions.php
+++ b/src/functions.php
@@ -20,13 +20,14 @@ use function Amp\Promise\any;
  * @return callable Callable executing in another thread / process.
  * @throws SerializationException If the passed callable is not safely serializable.
  */
-function parallel(callable $callable, Pool $pool = null): callable {
+function parallel(callable $callable, Pool $pool = null): callable
+{
     if ($callable instanceof \Closure) {
         $callable = new SerializableClosure($callable);
     }
 
     try {
-        $callable = serialize($callable);
+        $callable = \serialize($callable);
     } catch (\Throwable $e) {
         throw new SerializationException("Unsupported callable: " . $e->getMessage(), 0, $e);
     }
@@ -47,11 +48,12 @@ function parallel(callable $callable, Pool $pool = null): callable {
  * @return Promise Resolves to the result once the operation finished.
  * @throws \Error If the passed callable is not safely serializable.
  */
-function parallelMap(array $array, callable $callable, Pool $pool = null): Promise {
+function parallelMap(array $array, callable $callable, Pool $pool = null): Promise
+{
     return call(function () use ($array, $callable, $pool) {
         // Amp\Promise\any() guarantees that all operations finished prior to resolving. Amp\Promise\all() doesn't.
         // Additionally, we return all errors as a MultiReasonException instead of throwing on the first error.
-        list($errors, $results) = yield any(array_map(parallel($callable, $pool), $array));
+        list($errors, $results) = yield any(\array_map(parallel($callable, $pool), $array));
 
         if ($errors) {
             throw new MultiReasonException($errors);
@@ -72,7 +74,8 @@ function parallelMap(array $array, callable $callable, Pool $pool = null): Promi
  * @return Promise
  * @throws \Error If the passed callable is not safely serializable.
  */
-function parallelFilter(array $array, callable $callable = null, int $flag = 0, Pool $pool = null): Promise {
+function parallelFilter(array $array, callable $callable = null, int $flag = 0, Pool $pool = null): Promise
+{
     return call(function () use ($array, $callable, $flag, $pool) {
         if ($callable === null) {
             if ($flag === \ARRAY_FILTER_USE_BOTH || $flag === \ARRAY_FILTER_USE_KEY) {
@@ -87,11 +90,11 @@ function parallelFilter(array $array, callable $callable = null, int $flag = 0, 
         // Amp\Promise\any() guarantees that all operations finished prior to resolving. Amp\Promise\all() doesn't.
         // Additionally, we return all errors as a MultiReasonException instead of throwing on the first error.
         if ($flag === \ARRAY_FILTER_USE_BOTH) {
-            list($errors, $results) = yield any(array_map(parallel($callable, $pool), $array, array_keys($array)));
+            list($errors, $results) = yield any(\array_map(parallel($callable, $pool), $array, \array_keys($array)));
         } elseif ($flag === \ARRAY_FILTER_USE_KEY) {
-            list($errors, $results) = yield any(array_map(parallel($callable, $pool), array_keys($array)));
+            list($errors, $results) = yield any(\array_map(parallel($callable, $pool), \array_keys($array)));
         } else {
-            list($errors, $results) = yield any(array_map(parallel($callable, $pool), $array));
+            list($errors, $results) = yield any(\array_map(parallel($callable, $pool), $array));
         }
 
         if ($errors) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -26,7 +26,7 @@ function parallel(callable $callable, Pool $pool = null): callable {
     }
 
     try {
-        $callable = \serialize($callable);
+        $callable = serialize($callable);
     } catch (\Throwable $e) {
         throw new SerializationException("Unsupported callable: " . $e->getMessage(), 0, $e);
     }
@@ -51,7 +51,7 @@ function parallelMap(array $array, callable $callable, Pool $pool = null): Promi
     return call(function () use ($array, $callable, $pool) {
         // Amp\Promise\any() guarantees that all operations finished prior to resolving. Amp\Promise\all() doesn't.
         // Additionally, we return all errors as a MultiReasonException instead of throwing on the first error.
-        list($errors, $results) = yield any(\array_map(parallel($callable, $pool), $array));
+        list($errors, $results) = yield any(array_map(parallel($callable, $pool), $array));
 
         if ($errors) {
             throw new MultiReasonException($errors);
@@ -87,11 +87,11 @@ function parallelFilter(array $array, callable $callable = null, int $flag = 0, 
         // Amp\Promise\any() guarantees that all operations finished prior to resolving. Amp\Promise\all() doesn't.
         // Additionally, we return all errors as a MultiReasonException instead of throwing on the first error.
         if ($flag === \ARRAY_FILTER_USE_BOTH) {
-            list($errors, $results) = yield any(\array_map(parallel($callable, $pool), $array, \array_keys($array)));
+            list($errors, $results) = yield any(array_map(parallel($callable, $pool), $array, array_keys($array)));
         } elseif ($flag === \ARRAY_FILTER_USE_KEY) {
-            list($errors, $results) = yield any(\array_map(parallel($callable, $pool), \array_keys($array)));
+            list($errors, $results) = yield any(array_map(parallel($callable, $pool), array_keys($array)));
         } else {
-            list($errors, $results) = yield any(\array_map(parallel($callable, $pool), $array));
+            list($errors, $results) = yield any(array_map(parallel($callable, $pool), $array));
         }
 
         if ($errors) {

--- a/test/FilterTest.php
+++ b/test/FilterTest.php
@@ -3,45 +3,51 @@
 namespace Amp\ParallelFunctions\Test;
 
 use Amp\MultiReasonException;
-use function Amp\ParallelFunctions\parallelFilter;
 use Amp\PHPUnit\AsyncTestCase;
+use function Amp\ParallelFunctions\parallelFilter;
 use function Amp\Promise\wait;
 
-class FilterTest extends AsyncTestCase {
-    public function testWithoutCallback() {
+class FilterTest extends AsyncTestCase
+{
+    public function testWithoutCallback()
+    {
         $input = [1, 0, 3, false, true, null];
 
-        $this->assertSame(array_filter($input), wait(parallelFilter($input)));
+        $this->assertSame(\array_filter($input), wait(parallelFilter($input)));
     }
 
-    public function testWithCallback() {
+    public function testWithCallback()
+    {
         $input = [1, 0, 3, false, true, null];
         $callback = function ($value) {
             return $value === false;
         };
 
-        $this->assertSame(array_filter($input, $callback), wait(parallelFilter($input, $callback)));
+        $this->assertSame(\array_filter($input, $callback), wait(parallelFilter($input, $callback)));
     }
 
-    public function testWithCallbackAndFlagKey() {
+    public function testWithCallbackAndFlagKey()
+    {
         $input = [1, 0, 3, false, true, null];
         $callback = function ($key) {
             return $key === 2;
         };
 
-        $this->assertSame(array_filter($input, $callback, \ARRAY_FILTER_USE_KEY), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_KEY)));
+        $this->assertSame(\array_filter($input, $callback, \ARRAY_FILTER_USE_KEY), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_KEY)));
     }
 
-    public function testWithCallbackAndFlagBoth() {
+    public function testWithCallbackAndFlagBoth()
+    {
         $input = [1, 0, 3, false, true, null];
         $callback = function ($value, $key) {
             return $key === 2 || $value === true;
         };
 
-        $this->assertSame(array_filter($input, $callback, \ARRAY_FILTER_USE_BOTH), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_BOTH)));
+        $this->assertSame(\array_filter($input, $callback, \ARRAY_FILTER_USE_BOTH), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_BOTH)));
     }
 
-    public function testException() {
+    public function testException()
+    {
         $this->expectException(MultiReasonException::class);
 
         wait(parallelFilter([1, 2, 3], function () {
@@ -49,11 +55,12 @@ class FilterTest extends AsyncTestCase {
         }));
     }
 
-    public function testExecutesAllTasksOnException() {
+    public function testExecutesAllTasksOnException()
+    {
         $files = [
-            [0, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [1, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [2, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [0, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [1, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [2, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
         ];
 
         try {
@@ -64,8 +71,8 @@ class FilterTest extends AsyncTestCase {
                     throw new \Exception;
                 }
 
-                sleep(1);
-                file_put_contents($filename, $id);
+                \sleep(1);
+                \file_put_contents($filename, $id);
             }));
 
             $this->fail('No exception thrown.');
@@ -75,13 +82,14 @@ class FilterTest extends AsyncTestCase {
         }
     }
 
-    public function testFilterWithNullCallable() {
+    public function testFilterWithNullCallable()
+    {
         $this->expectException(\Error::class);
 
         $files = [
-            [0, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [1, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [2, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [0, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [1, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [2, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
         ];
 
         wait(parallelFilter($files, null, ARRAY_FILTER_USE_BOTH));

--- a/test/FilterTest.php
+++ b/test/FilterTest.php
@@ -11,7 +11,7 @@ class FilterTest extends AsyncTestCase {
     public function testWithoutCallback() {
         $input = [1, 0, 3, false, true, null];
 
-        $this->assertSame(\array_filter($input), wait(parallelFilter($input)));
+        $this->assertSame(array_filter($input), wait(parallelFilter($input)));
     }
 
     public function testWithCallback() {
@@ -20,7 +20,7 @@ class FilterTest extends AsyncTestCase {
             return $value === false;
         };
 
-        $this->assertSame(\array_filter($input, $callback), wait(parallelFilter($input, $callback)));
+        $this->assertSame(array_filter($input, $callback), wait(parallelFilter($input, $callback)));
     }
 
     public function testWithCallbackAndFlagKey() {
@@ -29,7 +29,7 @@ class FilterTest extends AsyncTestCase {
             return $key === 2;
         };
 
-        $this->assertSame(\array_filter($input, $callback, \ARRAY_FILTER_USE_KEY), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_KEY)));
+        $this->assertSame(array_filter($input, $callback, \ARRAY_FILTER_USE_KEY), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_KEY)));
     }
 
     public function testWithCallbackAndFlagBoth() {
@@ -38,7 +38,7 @@ class FilterTest extends AsyncTestCase {
             return $key === 2 || $value === true;
         };
 
-        $this->assertSame(\array_filter($input, $callback, \ARRAY_FILTER_USE_BOTH), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_BOTH)));
+        $this->assertSame(array_filter($input, $callback, \ARRAY_FILTER_USE_BOTH), wait(parallelFilter($input, $callback, \ARRAY_FILTER_USE_BOTH)));
     }
 
     public function testException() {
@@ -51,9 +51,9 @@ class FilterTest extends AsyncTestCase {
 
     public function testExecutesAllTasksOnException() {
         $files = [
-            [0, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [1, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [2, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [0, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [1, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [2, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
         ];
 
         try {
@@ -64,8 +64,8 @@ class FilterTest extends AsyncTestCase {
                     throw new \Exception;
                 }
 
-                \sleep(1);
-                \file_put_contents($filename, $id);
+                sleep(1);
+                file_put_contents($filename, $id);
             }));
 
             $this->fail('No exception thrown.');
@@ -79,9 +79,9 @@ class FilterTest extends AsyncTestCase {
         $this->expectException(\Error::class);
 
         $files = [
-            [0, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [1, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [2, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [0, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [1, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [2, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
         ];
 
         wait(parallelFilter($files, null, ARRAY_FILTER_USE_BOTH));

--- a/test/Fixture/TestCallables.php
+++ b/test/Fixture/TestCallables.php
@@ -2,16 +2,20 @@
 
 namespace Amp\ParallelFunctions\Test\Fixture;
 
-class TestCallables {
-    public static function staticMethod(int $value): int {
+class TestCallables
+{
+    public static function staticMethod(int $value): int
+    {
         return $value + 1;
     }
 
-    public function instanceMethod(int $value): int {
+    public function instanceMethod(int $value): int
+    {
         return $value + 2;
     }
 
-    public function __invoke(int $value) {
+    public function __invoke(int $value)
+    {
         return $value + 3;
     }
 }

--- a/test/MapTest.php
+++ b/test/MapTest.php
@@ -3,26 +3,30 @@
 namespace Amp\ParallelFunctions\Test;
 
 use Amp\MultiReasonException;
-use function Amp\ParallelFunctions\parallelMap;
 use Amp\PHPUnit\AsyncTestCase;
+use function Amp\ParallelFunctions\parallelMap;
 use function Amp\Promise\wait;
 
-class MapTest extends AsyncTestCase {
-    public function testValidInput() {
+class MapTest extends AsyncTestCase
+{
+    public function testValidInput()
+    {
         $this->assertSame([3, 4, 5], wait(parallelMap([1, 2, 3], function ($input) {
             return $input + 2;
         })));
     }
 
-    public function testCorrectOutputOrder() {
+    public function testCorrectOutputOrder()
+    {
         $this->assertSame([0, 1, 0], wait(parallelMap([0, 1, 0], function ($input) {
-            sleep($input);
+            \sleep($input);
 
             return $input;
         })));
     }
 
-    public function testException() {
+    public function testException()
+    {
         $this->expectException(MultiReasonException::class);
 
         wait(parallelMap([1, 2, 3], function () {
@@ -30,11 +34,12 @@ class MapTest extends AsyncTestCase {
         }));
     }
 
-    public function testExecutesAllTasksOnException() {
+    public function testExecutesAllTasksOnException()
+    {
         $files = [
-            [0, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [1, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [2, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [0, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [1, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [2, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
         ];
 
         try {
@@ -45,8 +50,8 @@ class MapTest extends AsyncTestCase {
                     throw new \Exception;
                 }
 
-                sleep(1);
-                file_put_contents($filename, $id);
+                \sleep(1);
+                \file_put_contents($filename, $id);
             }));
 
             $this->fail('No exception thrown.');

--- a/test/MapTest.php
+++ b/test/MapTest.php
@@ -16,7 +16,7 @@ class MapTest extends AsyncTestCase {
 
     public function testCorrectOutputOrder() {
         $this->assertSame([0, 1, 0], wait(parallelMap([0, 1, 0], function ($input) {
-            \sleep($input);
+            sleep($input);
 
             return $input;
         })));
@@ -32,9 +32,9 @@ class MapTest extends AsyncTestCase {
 
     public function testExecutesAllTasksOnException() {
         $files = [
-            [0, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [1, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
-            [2, \tempnam(\sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [0, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [1, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
+            [2, tempnam(sys_get_temp_dir(), 'amp-parallel-functions-')],
         ];
 
         try {
@@ -45,8 +45,8 @@ class MapTest extends AsyncTestCase {
                     throw new \Exception;
                 }
 
-                \sleep(1);
-                \file_put_contents($filename, $id);
+                sleep(1);
+                file_put_contents($filename, $id);
             }));
 
             $this->fail('No exception thrown.');

--- a/test/ParallelTest.php
+++ b/test/ParallelTest.php
@@ -4,25 +4,31 @@ namespace Amp\ParallelFunctions\Test;
 
 use Amp\Parallel\Sync\SerializationException;
 use Amp\Parallel\Worker\Pool;
-use function Amp\ParallelFunctions\parallel;
 use Amp\ParallelFunctions\Test\Fixture\TestCallables;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Promise;
 use Amp\Success;
+use function Amp\ParallelFunctions\parallel;
 
-class UnserializableClass {
-    public function __invoke() {
+class UnserializableClass
+{
+    public function __invoke()
+    {
     }
 
-    public function instanceMethod() {
+    public function instanceMethod()
+    {
     }
 
-    public static function staticMethod() {
+    public static function staticMethod()
+    {
     }
 }
 
-class ParallelTest extends AsyncTestCase {
-    public function testUnserializableClosure() {
+class ParallelTest extends AsyncTestCase
+{
+    public function testUnserializableClosure()
+    {
         $this->expectException(SerializationException::class);
         $this->expectExceptionMessage("Unsupported callable: Serialization of 'class@anonymous' is not allowed");
 
@@ -33,7 +39,8 @@ class ParallelTest extends AsyncTestCase {
         })());
     }
 
-    public function testCustomPool() {
+    public function testCustomPool()
+    {
         $mock = $this->createMock(Pool::class);
         $mock->expects($this->once())
             ->method("enqueue")
@@ -46,7 +53,8 @@ class ParallelTest extends AsyncTestCase {
         $this->assertSame(1, Promise\wait($callable()));
     }
 
-    public function testClassStaticMethod() {
+    public function testClassStaticMethod()
+    {
         $callable = [TestCallables::class, 'staticMethod'];
         $result = $callable(1);
         $callable = parallel($callable);
@@ -54,7 +62,8 @@ class ParallelTest extends AsyncTestCase {
         $this->assertSame($result, Promise\wait($callable(1)));
     }
 
-    public function testClassInstanceMethod() {
+    public function testClassInstanceMethod()
+    {
         $instance = new TestCallables;
 
         $callable = [$instance, 'instanceMethod'];
@@ -64,7 +73,8 @@ class ParallelTest extends AsyncTestCase {
         $this->assertSame($result, Promise\wait($callable(1)));
     }
 
-    public function testCallableClass() {
+    public function testCallableClass()
+    {
         $callable = new TestCallables;
         $result = $callable(1);
         $callable = parallel($callable);
@@ -72,19 +82,22 @@ class ParallelTest extends AsyncTestCase {
         $this->assertSame($result, Promise\wait($callable(1)));
     }
 
-    public function testUnserializableCallable() {
+    public function testUnserializableCallable()
+    {
         $this->expectException(SerializationException::class);
         $this->expectExceptionMessage("Unsupported callable: Serialization of 'class@anonymous' is not allowed");
 
         $callable = new class {
-            public function __invoke() {
+            public function __invoke()
+            {
             }
         };
 
         Promise\wait(parallel($callable)());
     }
 
-    public function testUnserializableClassInstance() {
+    public function testUnserializableClassInstance()
+    {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('Uncaught Error in worker with message "When using a class instance as a callable, the class must be autoloadable"');
 
@@ -95,7 +108,8 @@ class ParallelTest extends AsyncTestCase {
         Promise\wait($callable());
     }
 
-    public function testUnserializableClassInstanceMethod() {
+    public function testUnserializableClassInstanceMethod()
+    {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage('Uncaught Error in worker with message "When using a class instance method as a callable, the class must be autoloadable"');
 
@@ -106,7 +120,8 @@ class ParallelTest extends AsyncTestCase {
         Promise\wait($callable());
     }
 
-    public function testUnserializableClassStaticMethod() {
+    public function testUnserializableClassStaticMethod()
+    {
         $this->expectException(\Error::class);
         $this->expectExceptionMessage(
             PHP_VERSION_ID >= 80000 ?


### PR DESCRIPTION
This updates to PHP-CS-Fixer 3.x, and applies style fixes from the updated version.

Note: It looks like this strips the `\` prefix for global namespaced functions. This can be configured with [the `native_function_invocation` rule](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/function_notation/native_function_invocation.rst), however this is classed as risky so I wasn't sure whether to include it. 👍🏻 Let me know.